### PR TITLE
🧩 :: (#46) 학생 이메일 인증 api 추가

### DIFF
--- a/src/main/java/com/example/jobis/domain/student/controller/StudentController.java
+++ b/src/main/java/com/example/jobis/domain/student/controller/StudentController.java
@@ -1,0 +1,32 @@
+package com.example.jobis.domain.student.controller;
+
+import com.example.jobis.domain.student.controller.dto.request.SendAuthCodeRequest;
+import com.example.jobis.domain.student.controller.dto.request.VerifyAuthCodeRequest;
+import com.example.jobis.domain.student.service.SendSignUpAuthCodeService;
+import com.example.jobis.domain.student.service.VerifyAuthCodeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RequestMapping("/student")
+@RestController
+public class StudentController {
+
+    private final SendSignUpAuthCodeService sendSignUpAuthCodeService;
+    private final VerifyAuthCodeService verifyAuthCodeService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/code")
+    public void sendCode(@RequestBody @Valid SendAuthCodeRequest request) {
+        sendSignUpAuthCodeService.execute(request);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/code")
+    public void verifyCode(@RequestBody @Valid VerifyAuthCodeRequest request) {
+        verifyAuthCodeService.execute(request);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/controller/dto/request/SendAuthCodeRequest.java
+++ b/src/main/java/com/example/jobis/domain/student/controller/dto/request/SendAuthCodeRequest.java
@@ -1,0 +1,15 @@
+package com.example.jobis.domain.student.controller.dto.request;
+
+import com.example.jobis.global.util.RegexProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+public class SendAuthCodeRequest {
+
+    @Pattern(regexp = RegexProperty.EMAIL)
+    private String email;
+}

--- a/src/main/java/com/example/jobis/domain/student/controller/dto/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/com/example/jobis/domain/student/controller/dto/request/VerifyAuthCodeRequest.java
@@ -1,0 +1,21 @@
+package com.example.jobis.domain.student.controller.dto.request;
+
+import com.example.jobis.global.util.RegexProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor
+public class VerifyAuthCodeRequest {
+
+    @Pattern(regexp = RegexProperty.EMAIL)
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 6)
+    private String authCode;
+}

--- a/src/main/java/com/example/jobis/domain/student/domain/AuthCode.java
+++ b/src/main/java/com/example/jobis/domain/student/domain/AuthCode.java
@@ -1,0 +1,33 @@
+package com.example.jobis.domain.student.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Builder
+@RedisHash
+public class AuthCode {
+
+     @Id
+    private final String email;
+
+     private String code;
+
+     private boolean isVerified;
+
+     @TimeToLive
+    private Long ttl;
+
+     public void updateAuthCode(String code, Long ttl) {
+         this.code = code;
+         this.ttl = ttl;
+         this.isVerified = false;
+     }
+
+     public void verify() {
+         this.isVerified = true;
+     }
+}

--- a/src/main/java/com/example/jobis/domain/student/domain/Student.java
+++ b/src/main/java/com/example/jobis/domain/student/domain/Student.java
@@ -16,10 +16,6 @@ import javax.persistence.*;
 @Entity
 public class Student extends User {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "student_id")
-    private Long id;
-
     @Column(length = 10, nullable = false)
     private String name;
 

--- a/src/main/java/com/example/jobis/domain/student/domain/repository/AuthCodeRepository.java
+++ b/src/main/java/com/example/jobis/domain/student/domain/repository/AuthCodeRepository.java
@@ -1,0 +1,8 @@
+package com.example.jobis.domain.student.domain.repository;
+
+import com.example.jobis.domain.student.domain.AuthCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthCodeRepository extends JpaRepository<AuthCode, String> {
+
+}

--- a/src/main/java/com/example/jobis/domain/student/domain/repository/StudentRepository.java
+++ b/src/main/java/com/example/jobis/domain/student/domain/repository/StudentRepository.java
@@ -1,0 +1,9 @@
+package com.example.jobis.domain.student.domain.repository;
+
+import com.example.jobis.domain.student.domain.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudentRepository extends JpaRepository<Student, Long> {
+
+    boolean existsByAccountId(String accountId);
+}

--- a/src/main/java/com/example/jobis/domain/student/exception/BadAuthCodeException.java
+++ b/src/main/java/com/example/jobis/domain/student/exception/BadAuthCodeException.java
@@ -1,0 +1,13 @@
+package com.example.jobis.domain.student.exception;
+
+import com.example.jobis.global.error.exception.ErrorCode;
+import com.example.jobis.global.error.exception.JobisException;
+
+public class BadAuthCodeException extends JobisException {
+    public static final JobisException EXCEPTION =
+            new BadAuthCodeException();
+
+    private BadAuthCodeException() {
+        super(ErrorCode.BAD_AUTH_CODE);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/exception/BadEmailException.java
+++ b/src/main/java/com/example/jobis/domain/student/exception/BadEmailException.java
@@ -1,0 +1,13 @@
+package com.example.jobis.domain.student.exception;
+
+import com.example.jobis.global.error.exception.ErrorCode;
+import com.example.jobis.global.error.exception.JobisException;
+
+public class BadEmailException extends JobisException {
+    public static final JobisException EXCEPTION =
+            new BadEmailException();
+
+    private BadEmailException() {
+        super(ErrorCode.BAD_EMAIL);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/exception/StudentAlreadyExistsException.java
+++ b/src/main/java/com/example/jobis/domain/student/exception/StudentAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.example.jobis.domain.student.exception;
+
+import com.example.jobis.global.error.exception.ErrorCode;
+import com.example.jobis.global.error.exception.JobisException;
+
+public class StudentAlreadyExistsException extends JobisException {
+
+    public static final JobisException EXCEPTION =
+            new StudentAlreadyExistsException();
+
+    private StudentAlreadyExistsException() {
+        super(ErrorCode.STUDENT_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/exception/UnverifiedEmailException.java
+++ b/src/main/java/com/example/jobis/domain/student/exception/UnverifiedEmailException.java
@@ -1,0 +1,13 @@
+package com.example.jobis.domain.student.exception;
+
+import com.example.jobis.global.error.exception.ErrorCode;
+import com.example.jobis.global.error.exception.JobisException;
+
+public class UnverifiedEmailException extends JobisException {
+    public static final JobisException EXCEPTION =
+            new UnverifiedEmailException();
+
+    private UnverifiedEmailException() {
+        super(ErrorCode.UNVERIFIED_EMAIL);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/facade/AuthCodeFacade.java
+++ b/src/main/java/com/example/jobis/domain/student/facade/AuthCodeFacade.java
@@ -1,0 +1,73 @@
+package com.example.jobis.domain.student.facade;
+
+import com.example.jobis.domain.student.domain.AuthCode;
+import com.example.jobis.domain.student.domain.repository.AuthCodeRepository;
+import com.example.jobis.domain.student.exception.BadAuthCodeException;
+import com.example.jobis.domain.student.exception.BadEmailException;
+import com.example.jobis.domain.student.exception.UnverifiedEmailException;
+import com.example.jobis.global.util.RegexProperty;
+import com.example.jobis.global.util.jms.JmsProperties;
+import com.example.jobis.global.util.jms.JmsUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Component
+public class AuthCodeFacade {
+
+    private static final Random RANDOM = new Random();
+    private final AuthCodeRepository authCodeRepository;
+    private final JmsUtil jmsUtil;
+    private final JmsProperties jmsProperties;
+
+    public void verifyAuthCode(String code, String email) {
+        AuthCode authCode = authCodeRepository.findById(email)
+                .filter(a ->  a.getCode().equals(code))
+                .orElseThrow(() -> BadAuthCodeException.EXCEPTION);
+        authCode.verify();
+        authCodeRepository.save(authCode);
+    }
+
+    public void checkEmailDomain(String email) {
+        if (!email.matches(RegexProperty.EMAIL)) {
+            throw BadEmailException.EXCEPTION;
+        }
+    }
+
+    public void checkIsVerified(String email) {
+        authCodeRepository.findById(email)
+                .filter(AuthCode::isVerified)
+                .orElseThrow(() -> UnverifiedEmailException.EXCEPTION);
+    }
+
+    public void sendMail(String email) {
+        String code = createRandomCode();
+        AuthCode authCode = getAuthCode(email, code);
+        authCodeRepository.save(authCode);
+
+        jmsUtil.sendMail(email, authCode.getCode());
+    }
+
+    private AuthCode getAuthCode(String email, String code) {
+        AuthCode authCode = authCodeRepository.findById(email)
+                .orElseGet(() -> createAuthCode(email, code));
+
+        authCode.updateAuthCode(code, jmsProperties.getAuthExp());
+        return authCode;
+    }
+
+    private AuthCode createAuthCode(String email, String code) {
+        return AuthCode.builder()
+                .email(email)
+                .code(code)
+                .isVerified(false)
+                .ttl(jmsProperties.getAuthExp())
+                .build();
+    }
+
+    private String createRandomCode() {
+        return String.format("%06d", RANDOM.nextInt(1000000) % 1000000);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/facade/StudentFacade.java
+++ b/src/main/java/com/example/jobis/domain/student/facade/StudentFacade.java
@@ -1,0 +1,16 @@
+package com.example.jobis.domain.student.facade;
+
+import com.example.jobis.domain.student.domain.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class StudentFacade {
+
+    private final StudentRepository studentRepository;
+
+    public boolean existsEmail(String email) {
+        return studentRepository.existsByAccountId(email);
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/service/SendSignUpAuthCodeService.java
+++ b/src/main/java/com/example/jobis/domain/student/service/SendSignUpAuthCodeService.java
@@ -1,0 +1,25 @@
+package com.example.jobis.domain.student.service;
+
+import com.example.jobis.domain.student.controller.dto.request.SendAuthCodeRequest;
+import com.example.jobis.domain.student.exception.StudentAlreadyExistsException;
+import com.example.jobis.domain.student.facade.AuthCodeFacade;
+import com.example.jobis.domain.student.facade.StudentFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SendSignUpAuthCodeService {
+
+    private final AuthCodeFacade authCodeFacade;
+    private final StudentFacade studentFacade;
+
+    public void execute(SendAuthCodeRequest request) {
+
+        if (studentFacade.existsEmail(request.getEmail())) {
+            throw StudentAlreadyExistsException.EXCEPTION;
+        }
+        authCodeFacade.checkEmailDomain(request.getEmail());
+        authCodeFacade.sendMail(request.getEmail());
+    }
+}

--- a/src/main/java/com/example/jobis/domain/student/service/VerifyAuthCodeService.java
+++ b/src/main/java/com/example/jobis/domain/student/service/VerifyAuthCodeService.java
@@ -1,0 +1,19 @@
+package com.example.jobis.domain.student.service;
+
+import com.example.jobis.domain.student.controller.dto.request.VerifyAuthCodeRequest;
+import com.example.jobis.domain.student.facade.AuthCodeFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class VerifyAuthCodeService {
+
+    private final AuthCodeFacade authCodeFacade;
+
+    @Transactional
+    public void execute(VerifyAuthCodeRequest request) {
+        authCodeFacade.verifyAuthCode(request.getAuthCode(), request.getEmail());
+    }
+}

--- a/src/main/java/com/example/jobis/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/jobis/global/error/exception/ErrorCode.java
@@ -7,15 +7,22 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+
+    BAD_EMAIL(400, "Bad Email Domain"),
+
+    UNVERIFIED_EMAIL(401, "Unverified Email"),
+    BAD_AUTH_CODE(401, "Bad Auth Code"),
     EXPIRED_TOKEN(401,"Token Expired" ),
     INVALID_TOKEN(401,"Invalid Token"),
     INVALID_PASSWORD(401, "invalid password"),
     INVALID_CODE(401, "invalid code"),
 
     USER_NOT_FOUND(404, "User Not Found"),
-
     COMPANY_NOT_FOUND(404, "Company Not Found"),
-    COMPANY_ALREADY_EXISTS(409, "Company Already Exists")
+    MAIL_SEND_FAIL(404, "Mail Send Fail"),
+
+    COMPANY_ALREADY_EXISTS(409, "Company Already Exists"),
+    STUDENT_ALREADY_EXISTS(409, "Student Already Exists")
 
     ;
 

--- a/src/main/java/com/example/jobis/global/exception/MailSendException.java
+++ b/src/main/java/com/example/jobis/global/exception/MailSendException.java
@@ -1,0 +1,14 @@
+package com.example.jobis.global.exception;
+
+import com.example.jobis.global.error.exception.ErrorCode;
+import com.example.jobis.global.error.exception.JobisException;
+
+public class MailSendException extends JobisException {
+
+    public static final JobisException EXCEPTION =
+            new MailSendException();
+
+    private MailSendException() {
+        super(ErrorCode.MAIL_SEND_FAIL);
+    }
+}

--- a/src/main/java/com/example/jobis/global/util/RegexProperty.java
+++ b/src/main/java/com/example/jobis/global/util/RegexProperty.java
@@ -1,0 +1,9 @@
+package com.example.jobis.global.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RegexProperty {
+
+    public static final String EMAIL = "^.+@dsm.hs.kr$";
+}

--- a/src/main/java/com/example/jobis/global/util/jms/JmsProperties.java
+++ b/src/main/java/com/example/jobis/global/util/jms/JmsProperties.java
@@ -1,0 +1,17 @@
+package com.example.jobis.global.util.jms;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@AllArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.mail")
+public class JmsProperties {
+
+    private final String username;
+    private final Long authExp;
+    private final String suffix;
+}

--- a/src/main/java/com/example/jobis/global/util/jms/JmsUtil.java
+++ b/src/main/java/com/example/jobis/global/util/jms/JmsUtil.java
@@ -1,0 +1,36 @@
+package com.example.jobis.global.util.jms;
+
+import com.example.jobis.global.exception.MailSendException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+
+@RequiredArgsConstructor
+@Component
+public class JmsUtil {
+
+    private final JmsProperties jmsProperties;
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(String email, String authenticationCode) {
+
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, false, "UTF-8");
+
+            messageHelper.setTo(email);
+            messageHelper.setFrom(jmsProperties.getUsername());
+            messageHelper.setSubject("[JOBIS 메일 인증]");
+
+            String text = "인증코드 : " + authenticationCode;
+            messageHelper.setText(text);
+
+            javaMailSender.send(message);
+        } catch (Exception e) {
+            throw MailSendException.EXCEPTION;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,21 @@ spring:
   jackson:
     property-naming-strategy: SNAKE_CASE
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL-USERNAME}
+    password: ${EMAIL-PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            protocols: TLSv1.3
+          starttls:
+            enable: true
+            required: true
+
 redis:
   port: ${REDIS_PORT}
   host: ${REDIS_HOST}


### PR DESCRIPTION
### 해당 이슈⚡️

- close #46 

### 변경사항✅

- 학생 이메일 인증 api 추가
- 학생 엔티티 id 칼럼 삭제