### PR TITLE
🔗 :: (#191) 취업관리 회사리스트 조회 api

### DIFF
--- a/src/main/java/team/returm/jobis/domain/application/domain/Application.java
+++ b/src/main/java/team/returm/jobis/domain/application/domain/Application.java
@@ -39,7 +39,7 @@ public class Application extends BaseTimeEntity {
     @JoinColumn(name = "recruitment_id")
     private Recruitment recruitment;
 
-    @Column(columnDefinition = "VARCHAR(9)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(11)", nullable = false)
     @Enumerated(EnumType.STRING)
     private ApplicationStatus applicationStatus;
 

--- a/src/main/java/team/returm/jobis/domain/application/domain/enums/ApplicationStatus.java
+++ b/src/main/java/team/returm/jobis/domain/application/domain/enums/ApplicationStatus.java
@@ -5,5 +5,6 @@ public enum ApplicationStatus {
     REQUESTED,// 승인 요청
     APPROVED,// 승인
     FAILED,// 탈락
-    PASS// 통과
+    PASS,// 통과
+    FIELD_TRAIN// 현장실습
 }

--- a/src/main/java/team/returm/jobis/domain/company/domain/Company.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/Company.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import team.returm.jobis.domain.acceptance.domain.Acceptance;
 import team.returm.jobis.domain.company.domain.enums.CompanyType;
 import team.returm.jobis.domain.company.domain.type.Address;
 import team.returm.jobis.domain.company.domain.type.Manager;
@@ -102,6 +103,9 @@ public class Company {
 
     @OneToMany(mappedBy = "company")
     private List<CompanyAttachment> companyAttachments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "company")
+    private List<Acceptance> acceptances = new ArrayList<>();
 
     @Builder
     public Company(User user, String name, String mainAddress, String mainZipCode, String subAddress, String subZipCode,

--- a/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
@@ -19,8 +19,6 @@ import team.returm.jobis.domain.recruitment.domain.enums.RecruitStatus;
 import java.util.List;
 import java.util.Optional;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
 import static team.returm.jobis.domain.acceptance.domain.QAcceptance.acceptance;
 import static team.returm.jobis.domain.application.domain.QApplication.application;
 import static team.returm.jobis.domain.company.domain.QCompany.company;

--- a/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
@@ -5,16 +5,24 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.returm.jobis.domain.application.domain.enums.ApplicationStatus;
 import team.returm.jobis.domain.company.domain.Company;
+import team.returm.jobis.domain.company.domain.enums.CompanyType;
 import team.returm.jobis.domain.company.domain.repository.vo.QQueryCompanyDetailsVO;
 import team.returm.jobis.domain.company.domain.repository.vo.QStudentQueryCompaniesVO;
+import team.returm.jobis.domain.company.domain.repository.vo.QTeacherQueryEmployCompaniesVO;
 import team.returm.jobis.domain.company.domain.repository.vo.QueryCompanyDetailsVO;
 import team.returm.jobis.domain.company.domain.repository.vo.StudentQueryCompaniesVO;
+import team.returm.jobis.domain.company.domain.repository.vo.TeacherQueryEmployCompaniesVO;
 import team.returm.jobis.domain.recruitment.domain.enums.RecruitStatus;
 
 import java.util.List;
 import java.util.Optional;
 
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static team.returm.jobis.domain.acceptance.domain.QAcceptance.acceptance;
+import static team.returm.jobis.domain.application.domain.QApplication.application;
 import static team.returm.jobis.domain.company.domain.QCompany.company;
 import static team.returm.jobis.domain.company.domain.QCompanyAttachment.companyAttachment;
 import static team.returm.jobis.domain.recruitment.domain.QRecruitment.recruitment;
@@ -85,6 +93,38 @@ public class CompanyRepository {
                 .fetchOne();
     }
 
+    public List<TeacherQueryEmployCompaniesVO> queryEmployCompanies(String name, CompanyType type) {
+        return queryFactory
+                .select(
+                        new QTeacherQueryEmployCompaniesVO(
+                                company.id,
+                                company.name,
+                                application.count(),
+                                acceptance.count()
+                        )
+                )
+                .from(company)
+                .leftJoin(company.acceptances, acceptance)
+                .leftJoin(company.recruitmentList, recruitment)
+                .on(
+                        recruitment.company.id.eq(company.id),
+                        recruitment.createdAt.eq(
+                                JPAExpressions.select(recruitment.createdAt.max())
+                                        .from(recruitment)
+                                        .where(recruitment.company.id.eq(company.id))
+                        )
+                )
+                .leftJoin(recruitment.applications, application)
+                .on(application.applicationStatus.eq(ApplicationStatus.FIELD_TRAIN))
+                .where(
+                        containsName(name),
+                        eqCompanyType(type)
+                )
+                .orderBy(company.name.asc())
+                .groupBy(company.id, company.name)
+                .fetch();
+    }
+
     public List<String> queryCompanyAttachmentUrls(Long companyId) {
         return queryFactory
                 .select(companyAttachment.attachmentUrl)
@@ -119,4 +159,7 @@ public class CompanyRepository {
         return name == null ? null : company.name.contains(name);
     }
 
+    private BooleanExpression eqCompanyType(CompanyType type) {
+        return type == null ? null : company.type.eq(type);
+    }
 }

--- a/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
@@ -91,7 +91,7 @@ public class CompanyRepository {
                 .fetchOne();
     }
 
-    public List<TeacherQueryEmployCompaniesVO> queryEmployCompanies(String name, CompanyType type) {
+    public List<TeacherQueryEmployCompaniesVO> queryEmployCompanies(String name, CompanyType type, Integer year) {
         return queryFactory
                 .select(
                         new QTeacherQueryEmployCompaniesVO(
@@ -116,7 +116,8 @@ public class CompanyRepository {
                 .on(application.applicationStatus.eq(ApplicationStatus.FIELD_TRAIN))
                 .where(
                         containsName(name),
-                        eqCompanyType(type)
+                        eqCompanyType(type),
+                        eqYear(year)
                 )
                 .orderBy(company.name.asc())
                 .groupBy(company.id, company.name)
@@ -159,5 +160,9 @@ public class CompanyRepository {
 
     private BooleanExpression eqCompanyType(CompanyType type) {
         return type == null ? null : company.type.eq(type);
+    }
+
+    private BooleanExpression eqYear(Integer year) {
+        return year == null ? null : recruitment.recruitYear.eq(year);
     }
 }

--- a/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/repository/CompanyRepository.java
@@ -78,14 +78,7 @@ public class CompanyRepository {
                 .leftJoin(recruitment)
                 .on(
                         recruitment.company.id.eq(company.id),
-                        recruitment.createdAt.eq(
-                                JPAExpressions.select(recruitment.createdAt.max())
-                                        .from(recruitment)
-                                        .where(
-                                                recruitment.company.id.eq(company.id),
-                                                recruitment.status.eq(RecruitStatus.RECRUITING)
-                                        )
-                        )
+                        recentRecruitment(RecruitStatus.RECRUITING)
                 )
                 .where(company.id.eq(companyId))
                 .fetchOne();
@@ -106,11 +99,7 @@ public class CompanyRepository {
                 .leftJoin(company.recruitmentList, recruitment)
                 .on(
                         recruitment.company.id.eq(company.id),
-                        recruitment.createdAt.eq(
-                                JPAExpressions.select(recruitment.createdAt.max())
-                                        .from(recruitment)
-                                        .where(recruitment.company.id.eq(company.id))
-                        )
+                        recentRecruitment(null)
                 )
                 .leftJoin(recruitment.applications, application)
                 .on(application.applicationStatus.eq(ApplicationStatus.FIELD_TRAIN))
@@ -164,5 +153,20 @@ public class CompanyRepository {
 
     private BooleanExpression eqYear(Integer year) {
         return year == null ? null : recruitment.recruitYear.eq(year);
+    }
+
+    private BooleanExpression recentRecruitment(RecruitStatus status) {
+        return recruitment.createdAt.eq(
+                JPAExpressions.select(recruitment.createdAt.max())
+                        .from(recruitment)
+                        .where(
+                                recruitment.company.id.eq(company.id),
+                                eqRecruitmentStatus(status)
+                        )
+        );
+    }
+
+    private BooleanExpression eqRecruitmentStatus(RecruitStatus status) {
+        return status == null ? null : recruitment.status.eq(RecruitStatus.RECRUITING);
     }
 }

--- a/src/main/java/team/returm/jobis/domain/company/domain/repository/vo/TeacherQueryEmployCompaniesVO.java
+++ b/src/main/java/team/returm/jobis/domain/company/domain/repository/vo/TeacherQueryEmployCompaniesVO.java
@@ -1,0 +1,21 @@
+package team.returm.jobis.domain.company.domain.repository.vo;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class TeacherQueryEmployCompaniesVO {
+
+    private final Long companyId;
+    private final String companyName;
+    private final Long fieldTraineeCount;
+    private final Long contractCount;
+
+    @QueryProjection
+    public TeacherQueryEmployCompaniesVO(Long companyId, String companyName, Long fieldTraineeCount, Long contractCount) {
+        this.companyId = companyId;
+        this.companyName = companyName;
+        this.fieldTraineeCount = fieldTraineeCount;
+        this.contractCount = contractCount;
+    }
+}

--- a/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
+++ b/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
@@ -90,7 +90,7 @@ public class CompanyController {
     public TeacherQueryEmployCompaniesResponse queryEmployCompanies(
             @RequestParam(value = "company_name", required = false) String companyName,
             @RequestParam(value = "company_type", required = false) CompanyType type,
-            @RequestParam("year") Integer year
+            @RequestParam(value = "year", required = false) Integer year
             ) {
         return teacherQueryEmployCompaniesService.execute(companyName, type, year);
     }

--- a/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
+++ b/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
@@ -1,15 +1,18 @@
 package team.returm.jobis.domain.company.presentation;
 
+import team.returm.jobis.domain.company.domain.enums.CompanyType;
 import team.returm.jobis.domain.company.presentation.dto.request.UpdateCompanyDetailsRequest;
 import team.returm.jobis.domain.company.presentation.dto.response.QueryCompanyDetailsResponse;
 import team.returm.jobis.domain.company.presentation.dto.response.StudentQueryCompaniesResponse;
 import team.returm.jobis.domain.company.presentation.dto.response.CompanyMyPageResponse;
 import team.returm.jobis.domain.company.presentation.dto.response.CheckCompanyExistsResponse;
+import team.returm.jobis.domain.company.presentation.dto.response.TeacherQueryEmployCompaniesResponse;
 import team.returm.jobis.domain.company.service.CheckCompanyExistsService;
 import team.returm.jobis.domain.company.service.CompanyMyPageService;
 import team.returm.jobis.domain.company.service.QueryCompanyDetailsService;
 import team.returm.jobis.domain.company.service.RegisterCompanyService;
 import team.returm.jobis.domain.company.service.StudentQueryCompaniesService;
+import team.returm.jobis.domain.company.service.TeacherQueryEmployCompaniesService;
 import team.returm.jobis.domain.company.service.UpdateCompanyDetailsService;
 import team.returm.jobis.domain.user.presentation.dto.response.TokenResponse;
 import team.returm.jobis.domain.company.presentation.dto.request.RegisterCompanyRequest;
@@ -40,6 +43,7 @@ public class CompanyController {
     private final QueryCompanyDetailsService queryCompanyDetailsService;
     private final CompanyMyPageService companyMyPageService;
     private final UpdateCompanyTypeService updateCompanyTypeService;
+    private final TeacherQueryEmployCompaniesService teacherQueryEmployCompaniesService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -80,5 +84,13 @@ public class CompanyController {
     @PatchMapping("/type")
     public void updateCompanyType(@RequestBody @Valid UpdateCompanyTypeRequest request) {
         updateCompanyTypeService.execute(request);
+    }
+
+    @GetMapping("/teacher/employ")
+    public TeacherQueryEmployCompaniesResponse queryEmployCompanies(
+            @RequestParam(value = "company-name", required = false) String companyName,
+            @RequestParam(value = "company-type", required = false) CompanyType type
+            ) {
+        return teacherQueryEmployCompaniesService.execute(companyName, type);
     }
 }

--- a/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
+++ b/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
@@ -88,9 +88,10 @@ public class CompanyController {
 
     @GetMapping("/employment")
     public TeacherQueryEmployCompaniesResponse queryEmployCompanies(
-            @RequestParam(value = "company-name", required = false) String companyName,
-            @RequestParam(value = "company-type", required = false) CompanyType type
+            @RequestParam(value = "company_name", required = false) String companyName,
+            @RequestParam(value = "company_type", required = false) CompanyType type,
+            @RequestParam("year") Integer year
             ) {
-        return teacherQueryEmployCompaniesService.execute(companyName, type);
+        return teacherQueryEmployCompaniesService.execute(companyName, type, year);
     }
 }

--- a/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
+++ b/src/main/java/team/returm/jobis/domain/company/presentation/CompanyController.java
@@ -86,7 +86,7 @@ public class CompanyController {
         updateCompanyTypeService.execute(request);
     }
 
-    @GetMapping("/teacher/employ")
+    @GetMapping("/employment")
     public TeacherQueryEmployCompaniesResponse queryEmployCompanies(
             @RequestParam(value = "company-name", required = false) String companyName,
             @RequestParam(value = "company-type", required = false) CompanyType type

--- a/src/main/java/team/returm/jobis/domain/company/presentation/dto/response/TeacherQueryEmployCompaniesResponse.java
+++ b/src/main/java/team/returm/jobis/domain/company/presentation/dto/response/TeacherQueryEmployCompaniesResponse.java
@@ -1,0 +1,14 @@
+package team.returm.jobis.domain.company.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import team.returm.jobis.domain.company.domain.repository.vo.TeacherQueryEmployCompaniesVO;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TeacherQueryEmployCompaniesResponse {
+
+    private final List<TeacherQueryEmployCompaniesVO> companies;
+}

--- a/src/main/java/team/returm/jobis/domain/company/service/TeacherQueryEmployCompaniesService.java
+++ b/src/main/java/team/returm/jobis/domain/company/service/TeacherQueryEmployCompaniesService.java
@@ -1,0 +1,20 @@
+package team.returm.jobis.domain.company.service;
+
+import lombok.RequiredArgsConstructor;
+import team.returm.jobis.domain.company.domain.enums.CompanyType;
+import team.returm.jobis.domain.company.domain.repository.CompanyRepository;
+import team.returm.jobis.domain.company.presentation.dto.response.TeacherQueryEmployCompaniesResponse;
+import team.returm.jobis.global.annotation.ReadOnlyService;
+
+@RequiredArgsConstructor
+@ReadOnlyService
+public class TeacherQueryEmployCompaniesService {
+
+    private final CompanyRepository companyRepository;
+
+    public TeacherQueryEmployCompaniesResponse execute(String companyName, CompanyType type) {
+        return new TeacherQueryEmployCompaniesResponse(
+                companyRepository.queryEmployCompanies(companyName, type)
+        );
+    }
+}

--- a/src/main/java/team/returm/jobis/domain/company/service/TeacherQueryEmployCompaniesService.java
+++ b/src/main/java/team/returm/jobis/domain/company/service/TeacherQueryEmployCompaniesService.java
@@ -12,9 +12,9 @@ public class TeacherQueryEmployCompaniesService {
 
     private final CompanyRepository companyRepository;
 
-    public TeacherQueryEmployCompaniesResponse execute(String companyName, CompanyType type) {
+    public TeacherQueryEmployCompaniesResponse execute(String companyName, CompanyType type, Integer year) {
         return new TeacherQueryEmployCompaniesResponse(
-                companyRepository.queryEmployCompanies(companyName, type)
+                companyRepository.queryEmployCompanies(companyName, type, year)
         );
     }
 }

--- a/src/main/java/team/returm/jobis/global/security/SecurityConfig.java
+++ b/src/main/java/team/returm/jobis/global/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/companies/recruitment").hasAuthority(COMPANY.name())
                 .antMatchers(HttpMethod.GET, "/companies/{company-id}").hasAnyAuthority(STUDENT.name(), TEACHER.name())
                 .antMatchers(HttpMethod.GET, "/companies/student").hasAuthority(STUDENT.name())
-                .antMatchers(HttpMethod.GET, "/companies/teacher/employ").hasAnyAuthority(TEACHER.name())
+                .antMatchers(HttpMethod.GET, "/companies/employment").hasAnyAuthority(TEACHER.name())
 
                 //users
                 .antMatchers(HttpMethod.POST, "/users/login").permitAll()

--- a/src/main/java/team/returm/jobis/global/security/SecurityConfig.java
+++ b/src/main/java/team/returm/jobis/global/security/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/companies/recruitment").hasAuthority(COMPANY.name())
                 .antMatchers(HttpMethod.GET, "/companies/{company-id}").hasAnyAuthority(STUDENT.name(), TEACHER.name())
                 .antMatchers(HttpMethod.GET, "/companies/student").hasAuthority(STUDENT.name())
+                .antMatchers(HttpMethod.GET, "/companies/teacher/employ").hasAnyAuthority(TEACHER.name())
 
                 //users
                 .antMatchers(HttpMethod.POST, "/users/login").permitAll()


### PR DESCRIPTION
### PR 설명 🔎
- 취업 관리 페이지에서 사용되는 회사 리스트 조회 api를 만들었다.
- ApplicationStatus에 FIELD_TRIAN(현장실습) 추가

### 주요 변경사항 ✅
- TeacherQueryEmployCompaniesService


- [x] 로컬 테스트가 오류 없이 작동했나요?

close #191 