### PR TITLE
🔗 :: (#339)[BAC-413] 모집분야 삭제시 모집분야 개수 확인

### DIFF
--- a/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
@@ -164,10 +164,4 @@ public class Recruitment extends BaseTimeEntity {
             throw InvalidRecruitmentStatusException.EXCEPTION;
         }
     }
-
-    public void checkRecruitAreaCount() {
-        if (this.recruitAreas.size() <= 1) {
-            throw RecruitAreaCannotDeleteException.EXCEPTION;
-        }
-    }
 }

--- a/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
@@ -15,7 +15,6 @@ import team.retum.jobis.domain.recruitment.domain.type.PayInfo;
 import team.retum.jobis.domain.recruitment.domain.type.RecruitDate;
 import team.retum.jobis.domain.recruitment.exception.CompanyMismatchException;
 import team.retum.jobis.domain.recruitment.exception.InvalidRecruitmentStatusException;
-import team.retum.jobis.domain.recruitment.service.RecruitAreaCannotDeleteException;
 import team.retum.jobis.global.converter.StringListConverter;
 import team.retum.jobis.global.entity.BaseTimeEntity;
 

--- a/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/domain/Recruitment.java
@@ -15,6 +15,7 @@ import team.retum.jobis.domain.recruitment.domain.type.PayInfo;
 import team.retum.jobis.domain.recruitment.domain.type.RecruitDate;
 import team.retum.jobis.domain.recruitment.exception.CompanyMismatchException;
 import team.retum.jobis.domain.recruitment.exception.InvalidRecruitmentStatusException;
+import team.retum.jobis.domain.recruitment.service.RecruitAreaCannotDeleteException;
 import team.retum.jobis.global.converter.StringListConverter;
 import team.retum.jobis.global.entity.BaseTimeEntity;
 
@@ -161,6 +162,12 @@ public class Recruitment extends BaseTimeEntity {
     public void checkIsApplicatable() {
         if (this.status != RecruitStatus.RECRUITING) {
             throw InvalidRecruitmentStatusException.EXCEPTION;
+        }
+    }
+
+    public void checkRecruitAreaCount() {
+        if (this.recruitAreas.size() <= 1) {
+            throw RecruitAreaCannotDeleteException.EXCEPTION;
         }
     }
 }

--- a/src/main/java/team/retum/jobis/domain/recruitment/exception/error/RecruitmentErrorCode.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/exception/error/RecruitmentErrorCode.java
@@ -11,6 +11,7 @@ public enum RecruitmentErrorCode implements ErrorProperty {
 
     INVALID_RECRUITMENT_STATUS(HttpStatus.BAD_REQUEST, "Invalid Recruitment Status"),
 
+    RECRUIT_AREA_CANNOT_DELETE(HttpStatus.FORBIDDEN, "RecruitArea Cannot Delete"),
     RECRUITMENT_CANNOT_DELETE(HttpStatus.FORBIDDEN, "Recruitment Cannot Deleted"),
     COMPANY_MISMATCH(HttpStatus.FORBIDDEN, "Company Mismatch"),
 

--- a/src/main/java/team/retum/jobis/domain/recruitment/service/DeleteRecruitAreaService.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/service/DeleteRecruitAreaService.java
@@ -21,6 +21,9 @@ public class DeleteRecruitAreaService {
 
         RecruitArea recruitArea = recruitmentRepository.queryRecruitAreaById(recruitAreaId)
                 .orElseThrow(() -> RecruitAreaNotFoundException.EXCEPTION);
+
+        recruitArea.getRecruitment().checkRecruitAreaCount();
+
         if (user.getAuthority() == Authority.COMPANY) {
             recruitArea.getRecruitment().checkCompany(user.getId());
         }

--- a/src/main/java/team/retum/jobis/domain/recruitment/service/DeleteRecruitAreaService.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/service/DeleteRecruitAreaService.java
@@ -2,6 +2,7 @@ package team.retum.jobis.domain.recruitment.service;
 
 import lombok.RequiredArgsConstructor;
 import team.retum.jobis.domain.recruitment.domain.RecruitArea;
+import team.retum.jobis.domain.recruitment.domain.Recruitment;
 import team.retum.jobis.domain.recruitment.domain.repository.RecruitmentRepository;
 import team.retum.jobis.domain.recruitment.exception.RecruitAreaNotFoundException;
 import team.retum.jobis.domain.user.domain.User;
@@ -21,11 +22,14 @@ public class DeleteRecruitAreaService {
 
         RecruitArea recruitArea = recruitmentRepository.queryRecruitAreaById(recruitAreaId)
                 .orElseThrow(() -> RecruitAreaNotFoundException.EXCEPTION);
+        Recruitment recruitment = recruitArea.getRecruitment();
 
-        recruitArea.getRecruitment().checkRecruitAreaCount();
+        if (recruitment.getRecruitAreas().size() <= 1) {
+            throw RecruitAreaCannotDeleteException.EXCEPTION;
+        }
 
         if (user.getAuthority() == Authority.COMPANY) {
-            recruitArea.getRecruitment().checkCompany(user.getId());
+            recruitment.checkCompany(user.getId());
         }
 
         recruitmentRepository.deleteRecruitAreaById(recruitArea.getId());

--- a/src/main/java/team/retum/jobis/domain/recruitment/service/RecruitAreaCannotDeleteException.java
+++ b/src/main/java/team/retum/jobis/domain/recruitment/service/RecruitAreaCannotDeleteException.java
@@ -1,0 +1,13 @@
+package team.retum.jobis.domain.recruitment.service;
+
+import team.retum.jobis.domain.recruitment.exception.error.RecruitmentErrorCode;
+import team.retum.jobis.global.error.exception.JobisException;
+
+public class RecruitAreaCannotDeleteException extends JobisException {
+
+    public static final JobisException EXCEPTION = new RecruitAreaCannotDeleteException();
+
+    private RecruitAreaCannotDeleteException() {
+        super(RecruitmentErrorCode.RECRUIT_AREA_CANNOT_DELETE);
+    }
+}

--- a/src/main/java/team/retum/jobis/global/security/SecurityConfig.java
+++ b/src/main/java/team/retum/jobis/global/security/SecurityConfig.java
@@ -14,9 +14,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import team.retum.jobis.global.security.jwt.JwtTokenProvider;
 
 import static team.retum.jobis.domain.user.domain.enums.Authority.COMPANY;
+import static team.retum.jobis.domain.user.domain.enums.Authority.DEVELOPER;
 import static team.retum.jobis.domain.user.domain.enums.Authority.STUDENT;
 import static team.retum.jobis.domain.user.domain.enums.Authority.TEACHER;
-import static team.retum.jobis.domain.user.domain.enums.Authority.DEVELOPER;
 
 @EnableWebSecurity
 @Configuration


### PR DESCRIPTION
### PR 설명 🔎

- 모집 분야가 하나도 없는 경우를 방지하기 위해 모집분야 삭제시 개수를 확인하여 하나일때는 삭제 불가

### 주요 변경사항 ✅

- DeleteRecruitAreaService


- [X] 로컬 테스트가 오류 없이 작동했나요?

close #339 