### PR TITLE
🔗 :: (#713) 메서드 이름 통일

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/spi/CommandApplicationPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/spi/CommandApplicationPort.java
@@ -20,5 +20,5 @@ public interface CommandApplicationPort {
 
     void saveAll(List<Application> applications);
 
-    void deleteAllAttachmentByApplicationId(Long applicationId);
+    void deleteAllByApplicationId(Long applicationId);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/ReapplyUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/ReapplyUseCase.java
@@ -26,7 +26,7 @@ public class ReapplyUseCase {
             ApplicationStatus.REJECTED, ApplicationStatus.REQUESTED
         );
 
-        commandApplicationPort.deleteAllAttachmentByApplicationId(applicationId);
+        commandApplicationPort.deleteAllByApplicationId(applicationId);
         commandApplicationPort.save(
             application.reapply(ApplicationAttachment.from(attachmentRequests))
         );

--- a/jobis-application/src/main/java/team/retum/jobis/domain/bookmark/spi/CommandBookmarkPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/bookmark/spi/CommandBookmarkPort.java
@@ -4,7 +4,7 @@ import team.retum.jobis.domain.bookmark.model.Bookmark;
 
 public interface CommandBookmarkPort {
 
-    void saveBookmark(Bookmark bookmark);
+    void save(Bookmark bookmark);
 
-    void deleteBookmark(Bookmark bookmark);
+    void delete(Bookmark bookmark);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/bookmark/usecase/BookmarkUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/bookmark/usecase/BookmarkUseCase.java
@@ -25,8 +25,8 @@ public class BookmarkUseCase {
 
         queryBookmarkPort.getByRecruitmentIdAndStudentId(recruitment.getId(), student.getId())
             .ifPresentOrElse(
-                commandBookmarkPort::deleteBookmark,
-                () -> commandBookmarkPort.saveBookmark(Bookmark.builder()
+                commandBookmarkPort::delete,
+                () -> commandBookmarkPort.save(Bookmark.builder()
                     .studentId(student.getId())
                     .recruitmentId(recruitment.getId())
                     .build())

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/spi/CommandCompanyPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/spi/CommandCompanyPort.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface CommandCompanyPort {
 
-    Company saveCompany(Company company);
+    Company save(Company company);
 
-    void saveAllCompanies(List<Company> companies);
+    void saveAll(List<Company> companies);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/RegisterCompanyUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/RegisterCompanyUseCase.java
@@ -32,7 +32,7 @@ public class RegisterCompanyUseCase {
 
         Code code = queryCodePort.getByIdOrThrow(request.businessAreaCode());
 
-        Company savedCompany = commandCompanyPort.saveCompany(
+        Company savedCompany = commandCompanyPort.save(
             Company.of(request, code.getKeyword())
         );
 

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateCompanyDetailsUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateCompanyDetailsUseCase.java
@@ -26,6 +26,6 @@ public class UpdateCompanyDetailsUseCase {
             company.verifySameCompany(securityPort.getCurrentCompany());
         }
 
-        commandCompanyPort.saveCompany(company.update(request));
+        commandCompanyPort.save(company.update(request));
     }
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateCompanyTypeUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateCompanyTypeUseCase.java
@@ -23,7 +23,7 @@ public class UpdateCompanyTypeUseCase {
             throw CompanyNotFoundException.EXCEPTION;
         }
 
-        commandCompanyPort.saveAllCompanies(
+        commandCompanyPort.saveAll(
             companies.stream()
                 .map(company -> company.changeCompanyType(type))
                 .toList()

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateMouUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/usecase/UpdateMouUseCase.java
@@ -22,7 +22,7 @@ public class UpdateMouUseCase {
             throw CompanyNotFoundException.EXCEPTION;
         }
 
-        commandCompanyPort.saveAllCompanies(
+        commandCompanyPort.saveAll(
             companies.stream()
                 .map(Company::convertToMou)
                 .toList()

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interest/spi/CommandInterestPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interest/spi/CommandInterestPort.java
@@ -4,7 +4,7 @@ import team.retum.jobis.domain.interest.model.Interest;
 
 public interface CommandInterestPort {
 
-    void saveInterest(Interest interest);
+    void save(Interest interest);
 
-    void deleteInterest(Interest interest);
+    void delete(Interest interest);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interest/usecase/ToggleInterestUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interest/usecase/ToggleInterestUseCase.java
@@ -29,8 +29,8 @@ public class ToggleInterestUseCase {
 
             queryInterestPort.getByStudentIdAndCode(student.getId(), code.getId())
                 .ifPresentOrElse(
-                    commandInterestPort::deleteInterest,
-                    () -> commandInterestPort.saveInterest(
+                    commandInterestPort::delete,
+                    () -> commandInterestPort.save(
                         Interest.builder()
                             .studentId(student.getId())
                             .code(code.getId())

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/spi/CommandNoticePort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/spi/CommandNoticePort.java
@@ -4,8 +4,8 @@ import team.retum.jobis.domain.notice.model.Notice;
 
 public interface CommandNoticePort {
 
-    Notice saveNotice(Notice notice);
+    Notice save(Notice notice);
 
-    void deleteNotice(Notice notice);
+    void delete(Notice notice);
 
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/CreateNoticeUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/CreateNoticeUseCase.java
@@ -17,7 +17,7 @@ public class CreateNoticeUseCase {
     private final PublishEventPort publishEventPort;
 
     public void execute(CreateNoticeRequest request) {
-        Notice savedNotice = commandNoticePort.saveNotice(Notice.builder()
+        Notice savedNotice = commandNoticePort.save(Notice.builder()
             .title(request.getTitle())
             .content(request.getContent())
             .attachments(request.getAttachments().stream()

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/DeleteNoticeUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/DeleteNoticeUseCase.java
@@ -18,6 +18,6 @@ public class DeleteNoticeUseCase {
         Notice notice = queryNoticePort.getById(noticeId)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
 
-        commandNoticePort.deleteNotice(notice);
+        commandNoticePort.delete(notice);
     }
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/UpdateNoticeUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/UpdateNoticeUseCase.java
@@ -18,7 +18,7 @@ public class UpdateNoticeUseCase {
         Notice notice = queryNoticePort.getById(noticeId)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
 
-        commandNoticePort.saveNotice(
+        commandNoticePort.save(
             notice.update(
                 title,
                 content

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notification/spi/CommandNotificationPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notification/spi/CommandNotificationPort.java
@@ -5,7 +5,7 @@ import team.retum.jobis.domain.notification.model.Topic;
 
 public interface CommandNotificationPort {
 
-    void saveNotification(Notification notification);
+    void save(Notification notification);
 
     void unsubscribeTopic(String token, Topic topic);
 

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notification/spi/CommandTopicSubscriptionPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notification/spi/CommandTopicSubscriptionPort.java
@@ -4,5 +4,5 @@ import team.retum.jobis.domain.notification.model.TopicSubscription;
 
 public interface CommandTopicSubscriptionPort {
 
-    void saveTopicSubscription(TopicSubscription topicSubscription);
+    void save(TopicSubscription topicSubscription);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/ReadNotificationUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/ReadNotificationUseCase.java
@@ -18,6 +18,6 @@ public class ReadNotificationUseCase {
         Notification notification = queryNotificationPort.getById(notificationId)
             .orElseThrow(() -> NotificationNotFoundException.EXCEPTION);
 
-        commandNotificationPort.saveNotification(notification.read());
+        commandNotificationPort.save(notification.read());
     }
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/subscribe/SubscribeAllTopicsByToggleUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/subscribe/SubscribeAllTopicsByToggleUseCase.java
@@ -29,7 +29,7 @@ public class SubscribeAllTopicsByToggleUseCase {
         if (isSubscribed) {
             Arrays.stream(Topic.values()).forEach(topic -> {
                 commandNotificationPort.unsubscribeTopic(user.getToken(), topic);
-                commandTopicSubscriptionPort.saveTopicSubscription(
+                commandTopicSubscriptionPort.save(
                     TopicSubscription.builder()
                         .deviceToken(user.getToken())
                         .topic(topic)
@@ -40,7 +40,7 @@ public class SubscribeAllTopicsByToggleUseCase {
         } else {
             Arrays.stream(Topic.values()).forEach(topic -> {
                 commandNotificationPort.subscribeTopic(user.getToken(), topic);
-                commandTopicSubscriptionPort.saveTopicSubscription(
+                commandTopicSubscriptionPort.save(
                     TopicSubscription.builder()
                         .deviceToken(user.getToken())
                         .topic(topic)

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/subscribe/SubscribeTopicByToggleUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notification/usecase/subscribe/SubscribeTopicByToggleUseCase.java
@@ -27,7 +27,7 @@ public class SubscribeTopicByToggleUseCase {
                 subscription -> {
                     commandNotificationPort.unsubscribeTopic(user.getToken(), topic);
 
-                    commandTopicSubscriptionPort.saveTopicSubscription(
+                    commandTopicSubscriptionPort.save(
                         TopicSubscription.builder()
                             .deviceToken(user.getToken())
                             .topic(topic)
@@ -38,7 +38,7 @@ public class SubscribeTopicByToggleUseCase {
                 () -> {
                     commandNotificationPort.subscribeTopic(user.getToken(), topic);
 
-                    commandTopicSubscriptionPort.saveTopicSubscription(
+                    commandTopicSubscriptionPort.save(
                         TopicSubscription.builder()
                             .deviceToken(user.getToken())
                             .topic(topic)

--- a/jobis-application/src/main/java/team/retum/jobis/domain/review/spi/CommandReviewPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/review/spi/CommandReviewPort.java
@@ -9,7 +9,7 @@ public interface CommandReviewPort {
 
     Review save(Review review);
 
-    void saveAllQnAs(List<QnA> qnAs);
+    void saveAll(List<QnA> qnAs);
 
     void delete(Review review);
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/review/usecase/CreateReviewUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/review/usecase/CreateReviewUseCase.java
@@ -8,7 +8,6 @@ import team.retum.jobis.domain.company.exception.CompanyNotFoundException;
 import team.retum.jobis.domain.company.model.Company;
 import team.retum.jobis.domain.company.spi.QueryCompanyPort;
 import team.retum.jobis.domain.review.dto.QnAElement;
-import team.retum.jobis.domain.review.exception.ReviewAlreadyExistsException;
 import team.retum.jobis.domain.review.model.QnA;
 import team.retum.jobis.domain.review.model.Review;
 import team.retum.jobis.domain.review.spi.ReviewPort;
@@ -48,6 +47,6 @@ public class CreateReviewUseCase {
                 .codeId(qnARequest.codeId())
                 .build())
             .toList();
-        reviewPort.saveAllQnAs(qnAs);
+        reviewPort.saveAll(qnAs);
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
@@ -27,14 +27,14 @@ public class InterestPersistenceAdapter implements InterestPort {
     private final QueryCodePort queryCodePort;
 
     @Override
-    public void saveInterest(Interest interest) {
+    public void save(Interest interest) {
         interestMapper.toDomain(
                 interestJpaRepository.save(interestMapper.toEntity(interest))
         );
     }
 
     @Override
-    public void deleteInterest(Interest interest) {
+    public void delete(Interest interest) {
         interestJpaRepository.delete(interestMapper.toEntity(interest));
     }
 

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/application/persistence/ApplicationPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/application/persistence/ApplicationPersistenceAdapter.java
@@ -313,7 +313,7 @@ public class ApplicationPersistenceAdapter implements ApplicationPort {
     }
 
     @Override
-    public void deleteAllAttachmentByApplicationId(Long applicationId) {
+    public void deleteAllByApplicationId(Long applicationId) {
         queryFactory.delete(applicationAttachmentEntity)
             .where(applicationAttachmentEntity.application.id.eq(applicationId))
             .execute();

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/bookmark/persistence/BookmarkPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/bookmark/persistence/BookmarkPersistenceAdapter.java
@@ -32,7 +32,7 @@ public class BookmarkPersistenceAdapter implements BookmarkPort {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public void saveBookmark(Bookmark bookmark) {
+    public void save(Bookmark bookmark) {
         bookmarkJpaRepository.save(
             bookmarkMapper.toEntity(bookmark)
         );
@@ -45,7 +45,7 @@ public class BookmarkPersistenceAdapter implements BookmarkPort {
     }
 
     @Override
-    public void deleteBookmark(Bookmark bookmark) {
+    public void delete(Bookmark bookmark) {
         bookmarkJpaRepository.delete(
             bookmarkMapper.toEntity(bookmark)
         );

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/company/persistence/CompanyPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/company/persistence/CompanyPersistenceAdapter.java
@@ -60,7 +60,7 @@ public class CompanyPersistenceAdapter implements CompanyPort {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Company saveCompany(Company company) {
+    public Company save(Company company) {
         return companyMapper.toDomain(
             companyJpaRepository.save(
                 companyMapper.toEntity(company)
@@ -69,7 +69,7 @@ public class CompanyPersistenceAdapter implements CompanyPort {
     }
 
     @Override
-    public void saveAllCompanies(List<Company> companies) {
+    public void saveAll(List<Company> companies) {
         companyJpaRepository.saveAll(
             companies.stream()
                 .map(companyMapper::toEntity)

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notice/persistence/NoticePersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notice/persistence/NoticePersistenceAdapter.java
@@ -25,7 +25,7 @@ public class NoticePersistenceAdapter implements NoticePort {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Notice saveNotice(Notice notice) {
+    public Notice save(Notice notice) {
         return noticeMapper.toDomain(noticeJpaRepository.save(noticeMapper.toEntity(notice)));
     }
 
@@ -36,7 +36,7 @@ public class NoticePersistenceAdapter implements NoticePort {
     }
 
     @Override
-    public void deleteNotice(Notice notice) {
+    public void delete(Notice notice) {
         noticeJpaRepository.delete(noticeMapper.toEntity(notice));
     }
 

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notification/persistence/NotificationPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notification/persistence/NotificationPersistenceAdapter.java
@@ -32,7 +32,7 @@ public class NotificationPersistenceAdapter implements NotificationPort {
     private final FCMUtil fcmUtil;
 
     @Override
-    public void saveNotification(Notification notification) {
+    public void save(Notification notification) {
         notificationJpaRepository.save(notificationMapper.toEntity(notification));
     }
 

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notification/persistence/TopicSubscriptionPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/notification/persistence/TopicSubscriptionPersistenceAdapter.java
@@ -44,7 +44,7 @@ public class TopicSubscriptionPersistenceAdapter implements TopicSubscriptionPor
     }
 
     @Override
-    public void saveTopicSubscription(TopicSubscription topicSubscription) {
+    public void save(TopicSubscription topicSubscription) {
         topicSubscriptionJpaRepository.save(topicSubscriptionMapper.toEntity(topicSubscription));
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/review/persistence/ReviewPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/review/persistence/ReviewPersistenceAdapter.java
@@ -44,7 +44,7 @@ public class ReviewPersistenceAdapter implements ReviewPort {
     }
 
     @Override
-    public void saveAllQnAs(List<QnA> qnAs) {
+    public void saveAll(List<QnA> qnAs) {
         qnAJpaRepository.saveAll(
             qnAs.stream()
                 .map(qnAMapper::toEntity)

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/event/application/ApplicationEventHandler.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/event/application/ApplicationEventHandler.java
@@ -63,7 +63,7 @@ public class ApplicationEventHandler {
                 .isNew(true)
                 .build();
 
-            commandNotificationPort.saveNotification(notification);
+            commandNotificationPort.save(notification);
             fcmUtil.sendMessages(
                 notification,
                 List.of(userIdTokenMap.get(application.getStudentId()))

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/event/notice/NoticeEventHandler.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/event/notice/NoticeEventHandler.java
@@ -31,7 +31,7 @@ public class NoticeEventHandler {
             .isNew(true)
             .build();
 
-        commandNotificationPort.saveNotification(notification);
+        commandNotificationPort.save(notification);
 
         fcmUtil.sendMessageToTopic(notification);
     }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/event/recruitment/RecruitmentEventHandler.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/event/recruitment/RecruitmentEventHandler.java
@@ -64,7 +64,7 @@ public class RecruitmentEventHandler {
                     repNotification = notification;
                 }
                 tokens.add(bookmarkUser.getToken());
-                commandNotificationPort.saveNotification(notification);
+                commandNotificationPort.save(notification);
             }
             fcmUtil.sendMessages(repNotification, tokens);
         }
@@ -99,7 +99,7 @@ public class RecruitmentEventHandler {
                     repNotification = notification;
                 }
                 tokens.add(user.getToken());
-                commandNotificationPort.saveNotification(notification);
+                commandNotificationPort.save(notification);
             }
             fcmUtil.sendMessages(repNotification, tokens);
         }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] commandPort의 save와 delete 메서드의 도메인이름을 명시해주지 않도록 변경했습니다
- [ ] <!-- 작업 내용 작성 -->

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #713 