### PR TITLE
 🔗 :: (#724) 관심사 토글 조회 로직 변경

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/interest/spi/QueryInterestPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interest/spi/QueryInterestPort.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface QueryInterestPort {
 
-    Optional<Interest> getByStudentIdAndCode(Long studentId, Long code);
+    List<Interest> getAllByStudentIdAndCodes(Long studentId, List<Long> codes);
 
     List<Interest> getAllByStudentId(Long studentId);
 

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interest/usecase/ToggleInterestUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interest/usecase/ToggleInterestUseCase.java
@@ -3,8 +3,6 @@ package team.retum.jobis.domain.interest.usecase;
 import lombok.RequiredArgsConstructor;
 import team.retum.jobis.common.annotation.UseCase;
 import team.retum.jobis.common.spi.SecurityPort;
-import team.retum.jobis.domain.code.model.Code;
-import team.retum.jobis.domain.code.spi.QueryCodePort;
 import team.retum.jobis.domain.interest.model.Interest;
 import team.retum.jobis.domain.interest.spi.CommandInterestPort;
 import team.retum.jobis.domain.interest.spi.QueryInterestPort;
@@ -18,22 +16,19 @@ public class ToggleInterestUseCase {
 
     private final QueryInterestPort queryInterestPort;
     private final CommandInterestPort commandInterestPort;
-    private final QueryCodePort queryCodePort;
     private final SecurityPort securityPort;
 
     public void execute(List<Long> codeIds) {
         Student student = securityPort.getCurrentStudent();
 
         for (Long codeId : codeIds) {
-            Code code = queryCodePort.getByIdOrThrow(codeId);
-
-            queryInterestPort.getByStudentIdAndCode(student.getId(), code.getId())
+            queryInterestPort.getByStudentIdAndCode(student.getId(), codeId)
                 .ifPresentOrElse(
                     commandInterestPort::delete,
                     () -> commandInterestPort.save(
                         Interest.builder()
                             .studentId(student.getId())
-                            .code(code.getId())
+                            .code(codeId)
                             .build()
                     )
                 );

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
@@ -47,7 +47,6 @@ public class InterestPersistenceAdapter implements InterestPort {
             .map(interestMapper::toDomain);
     }
 
-
     @Override
     public List<Interest> getAllByStudentId(Long studentId) {
         return interestJpaRepository.findByStudentId(studentId).stream()

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/InterestPersistenceAdapter.java
@@ -39,12 +39,10 @@ public class InterestPersistenceAdapter implements InterestPort {
     }
 
     @Override
-    public Optional<Interest> getByStudentIdAndCode(Long studentId, Long code) {
-        CodeEntity codeEntity = codeJpaRepository.findById(code)
-            .orElseThrow(() -> CodeNotFoundException.EXCEPTION);
-
-        return interestJpaRepository.findByStudentIdAndCode(studentId, codeEntity)
-            .map(interestMapper::toDomain);
+    public List<Interest> getAllByStudentIdAndCodes(Long studentId, List<Long> codes) {
+        return interestJpaRepository.findByStudentId(studentId).stream()
+            .map(interestMapper::toDomain)
+            .toList();
     }
 
     @Override

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/repository/InterestJpaRepository.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/Interest/persistence/repository/InterestJpaRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface InterestJpaRepository extends CrudRepository<InterestEntity, Long> {
 
-    Optional<InterestEntity> findByStudentIdAndCode(Long studentId, CodeEntity codeEntity);
+    List<InterestEntity> findByStudentIdAndCodeIn(Long studentId, List<CodeEntity> codeEntity);
 
     List<InterestEntity> findByStudentId(Long studentId);
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] for문 안에 쿼리문이 존재해 codeId의 개수만큼 쿼리문이 실행되던 로직을 변경했습니다
- [ ] 한 번에 모든 interests를 조회해 codeId를 추출해 codeId가 이미 존재하면 삭제, 존재하지 않으면 Interest를 생성해줍니다

## 결과물(있으면)
### 변경 전
![image3](https://github.com/user-attachments/assets/424b95e9-39ca-4315-b94f-5cf5e7ee38eb)

### 변경 후 
![image7](https://github.com/user-attachments/assets/caa59667-f4cb-45fc-9d7c-7e08a9088fbe)

## 체크리스트
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #724 