### PR TITLE
🔗 :: (#775) deviceToken 삭제 API 추가

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/user/model/User.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/user/model/User.java
@@ -26,6 +26,12 @@ public class User {
             .build();
     }
 
+    public User removeDeviceToken() {
+        return this.toBuilder()
+            .token(null)
+            .build();
+    }
+
     public User setToken(String token) {
         if (token != null) {
             return this.toBuilder()

--- a/jobis-application/src/main/java/team/retum/jobis/domain/user/usecase/RemoveDeviceTokenUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/user/usecase/RemoveDeviceTokenUseCase.java
@@ -1,0 +1,23 @@
+package team.retum.jobis.domain.user.usecase;
+
+import lombok.RequiredArgsConstructor;
+import team.retum.jobis.common.annotation.UseCase;
+import team.retum.jobis.common.spi.SecurityPort;
+import team.retum.jobis.domain.user.model.User;
+import team.retum.jobis.domain.user.spi.CommandUserPort;
+
+@RequiredArgsConstructor
+@UseCase
+public class RemoveDeviceTokenUseCase {
+
+    private final SecurityPort securityPort;
+    private final CommandUserPort commandUserPort;
+
+    public void execute() {
+        User user = securityPort.getCurrentUser();
+
+        commandUserPort.save(
+            user.removeDeviceToken()
+        );
+    }
+}

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/user/presentation/UserWebAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/user/presentation/UserWebAdapter.java
@@ -33,7 +33,7 @@ public class UserWebAdapter {
         setDeviceTokenUseCase.execute(request.getToken());
     }
 
-    @PatchMapping("/device_token")
+    @PatchMapping("/device-token")
     public void removeDeviceToken() {
         removeDeviceTokenUseCase.execute();
     }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/user/presentation/UserWebAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/user/presentation/UserWebAdapter.java
@@ -11,6 +11,7 @@ import team.retum.jobis.domain.auth.dto.response.TokenResponse;
 import team.retum.jobis.domain.user.presentation.dto.request.LoginWebRequest;
 import team.retum.jobis.domain.user.presentation.dto.request.SetDeviceTokenWebRequest;
 import team.retum.jobis.domain.user.usecase.LoginUseCase;
+import team.retum.jobis.domain.user.usecase.RemoveDeviceTokenUseCase;
 import team.retum.jobis.domain.user.usecase.SetDeviceTokenUseCase;
 
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class UserWebAdapter {
 
     private final LoginUseCase loginUseCase;
     private final SetDeviceTokenUseCase setDeviceTokenUseCase;
+    private final RemoveDeviceTokenUseCase removeDeviceTokenUseCase;
 
     @PostMapping("/login")
     public TokenResponse login(@RequestBody @Valid LoginWebRequest request) {
@@ -29,5 +31,10 @@ public class UserWebAdapter {
     @PatchMapping("/token")
     public void setToken(@RequestBody @Valid SetDeviceTokenWebRequest request) {
         setDeviceTokenUseCase.execute(request.getToken());
+    }
+
+    @PatchMapping("/device_token")
+    public void removeDeviceToken() {
+        removeDeviceTokenUseCase.execute();
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] deviceToken의 중복을 피하기 위해 사용자가 로그아웃 시 deviceToken을 삭제할 수 있도록 deviceToken 삭제 api를 추가합니다
- [ ] securityConfig 는 명시적으로라도 추가하는게 좋은 것 같은데.. 일단 컨벤션 따름

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #775 