### PR TITLE
🔗 :: (#967) 공지 수정되었을 시 알림 추가

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/event/NoticeUpdatedEvent.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/event/NoticeUpdatedEvent.java
@@ -1,0 +1,12 @@
+package team.retum.jobis.domain.notice.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import team.retum.jobis.domain.notice.model.Notice;
+
+@Getter
+@AllArgsConstructor
+public class NoticeUpdatedEvent {
+
+    private final Notice notice;
+}

--- a/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/UpdateNoticeUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/notice/usecase/UpdateNoticeUseCase.java
@@ -2,6 +2,8 @@ package team.retum.jobis.domain.notice.usecase;
 
 import lombok.RequiredArgsConstructor;
 import team.retum.jobis.common.annotation.UseCase;
+import team.retum.jobis.common.spi.PublishEventPort;
+import team.retum.jobis.domain.notice.event.NoticeUpdatedEvent;
 import team.retum.jobis.domain.notice.exception.NoticeNotFoundException;
 import team.retum.jobis.domain.notice.model.Notice;
 import team.retum.jobis.domain.notice.spi.CommandNoticePort;
@@ -13,16 +15,19 @@ public class UpdateNoticeUseCase {
 
     private final CommandNoticePort commandNoticePort;
     private final QueryNoticePort queryNoticePort;
+    private final PublishEventPort eventPublisher;
 
     public void execute(String title, String content, Long noticeId) {
         Notice notice = queryNoticePort.getById(noticeId)
             .orElseThrow(() -> NoticeNotFoundException.EXCEPTION);
 
-        commandNoticePort.save(
+        Notice updatedNotice = commandNoticePort.save(
             notice.update(
                 title,
                 content
             )
         );
+
+        eventPublisher.publishEvent(new NoticeUpdatedEvent(updatedNotice));
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 공지 수정 시 알림 발송을 위한 이벤트 핸들러와 유스케이스 이벤트 발행 로직을 구현하였습니다.

## 결과물(있으면)
수정된 공지사항이 큐에 담긴 모습
![image](https://github.com/user-attachments/assets/69ec1c83-9e9d-4ae6-8262-9cfcb0dd1090)


## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- #967 