### PR TITLE
🔗 :: (#1020) 지원서 서류 탈락 상태 추가

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/model/ApplicationStatus.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/model/ApplicationStatus.java
@@ -12,6 +12,7 @@ public enum ApplicationStatus {
     REQUESTED("승인 요청"),
     APPROVED("승인"),
     SEND("기업에게 전송"),
+    DOC_FAILED("서류 탈락"),
     PROCESSING("진행중"),
     FAILED("탈락"),
     PASS("합격"),

--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/CreateNonSchoolContactPassApplicationsUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/CreateNonSchoolContactPassApplicationsUseCase.java
@@ -23,6 +23,7 @@ import java.util.List;
 @UseCase
 @RequiredArgsConstructor
 public class CreateNonSchoolContactPassApplicationsUseCase {
+
     private final CommandApplicationPort commandApplicationPort;
     private final QueryStudentPort queryStudentPort;
     private final QueryApplicationPort queryApplicationPort;


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 기존에 하나만 있었던 지원서의 탈락 상태를 서류 탈락과 탈락으로 구분하여 서류를 탈락하여도 면접 후기를 작성할 수 있었던 기존 문제를 해결

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- #1020 