### PR TITLE
🔗 :: (#1054) 취업 현황 조회 API에 년도 파라미터 추가

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/QueryEmploymentRateUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/QueryEmploymentRateUseCase.java
@@ -20,12 +20,12 @@ public class QueryEmploymentRateUseCase {
     private static final Integer FIRTH_CLASS = 1;
     private static final Integer FOURTH_CLASS = 4;
 
-    public EmploymentRatesResponse execute() {
+    public EmploymentRatesResponse execute(int year) {
         List<ClassResponse> classResponses = new ArrayList<>();
 
         for (Integer classNum = FIRTH_CLASS; classNum <= FOURTH_CLASS; classNum++) {
-            List<CompanyVO> companies = queryCompanyPort.getEmploymentRateByClassNumber(classNum);
-            long totalStudents = queryStudentPort.getTotalStudentsByClassNumber(classNum);
+            List<CompanyVO> companies = queryCompanyPort.getEmploymentRateByClassNumber(classNum, year);
+            long totalStudents = queryStudentPort.getTotalStudentsByClassNumber(classNum, year);
             long passedStudents = companies.size();
 
             classResponses.add(new ClassResponse(classNum, companies, totalStudents, passedStudents));

--- a/jobis-application/src/main/java/team/retum/jobis/domain/company/spi/QueryCompanyPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/company/spi/QueryCompanyPort.java
@@ -39,6 +39,6 @@ public interface QueryCompanyPort {
 
     Map<Long, String> getCompanyNameByRecruitmentIds(List<Long> recruitmentIds);
 
-    List<CompanyVO> getEmploymentRateByClassNumber(Integer classNum);
+    List<CompanyVO> getEmploymentRateByClassNumber(Integer classNum, int year);
 
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/student/spi/QueryStudentPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/student/spi/QueryStudentPort.java
@@ -18,7 +18,7 @@ public interface QueryStudentPort {
 
     List<Student> getByInterestCode(List<Long> code);
 
-    Long getTotalStudentsByClassNumber(Integer classNum);
+    Long getTotalStudentsByClassNumber(Integer classNum, int year);
 
     Long getPassedStudentsByClassNumber(Integer classNum);
 

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/application/presentation/ApplicationWebAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/application/presentation/ApplicationWebAdapter.java
@@ -246,9 +246,11 @@ public class ApplicationWebAdapter {
     }
 
     @Cacheable
-    @GetMapping("/employment")
-    public EmploymentRatesResponse queryEmploymentRate() {
-        return queryEmploymentRateUseCase.execute();
+    @GetMapping("/employment/{year}")
+    public EmploymentRatesResponse queryEmploymentRate(
+        @PathVariable("year") int year
+    ) {
+        return queryEmploymentRateUseCase.execute(year);
     }
 
     @PostMapping("/teacher/{recruitment-id}")

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/company/persistence/CompanyPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/company/persistence/CompanyPersistenceAdapter.java
@@ -326,7 +326,7 @@ public class CompanyPersistenceAdapter implements CompanyPort {
     }
 
     @Override
-    public List<CompanyVO> getEmploymentRateByClassNumber(Integer classNum) {
+    public List<CompanyVO> getEmploymentRateByClassNumber(Integer classNum, int year) {
         return queryFactory
             .select(
                 Projections.constructor(CompanyVO.class,
@@ -342,7 +342,7 @@ public class CompanyPersistenceAdapter implements CompanyPort {
             .innerJoin(companyEntity).on(recruitmentEntity.company.id.eq(companyEntity.id))
             .where(
                 studentEntity.classRoom.eq(classNum),
-                numberTemplate(Integer.class, "YEAR(CURRENT_DATE)").subtract(studentEntity.entranceYear).eq(2)
+                studentEntity.entranceYear.eq(year - 2)
             )
             .fetch();
     }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/student/persistence/StudentPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/student/persistence/StudentPersistenceAdapter.java
@@ -87,13 +87,12 @@ public class StudentPersistenceAdapter implements StudentPort {
     }
 
     @Override
-    public Long getTotalStudentsByClassNumber(Integer classNum) {
+    public Long getTotalStudentsByClassNumber(Integer classNum, int year) {
         return queryFactory
             .select(studentEntity.count())
             .from(studentEntity)
             .where(studentEntity.classRoom.eq(classNum)
-                .and(numberTemplate(Integer.class, "YEAR(CURRENT_DATE)")
-                    .subtract(studentEntity.entranceYear).eq(2)))
+                .and(studentEntity.entranceYear.eq(year - 2)))
             .fetchOne();
     }
 

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/global/security/SecurityConfig.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/global/security/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/applications/rejection/{application-id}").hasAnyAuthority(STUDENT.name(), DEVELOPER.name())
                     .requestMatchers(HttpMethod.GET, "/applications/count").hasAuthority(TEACHER.name())
                     .requestMatchers(HttpMethod.DELETE, "/applications").hasAuthority(TEACHER.name())
-                    .requestMatchers(HttpMethod.GET, "/applications/employment").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/applications/employment/{year}").permitAll()
                     .requestMatchers(HttpMethod.POST, "/applications/teacher/{recruitment-id}").hasAuthority(TEACHER.name())
 
                     // bookmarks


### PR DESCRIPTION
## 작업 내용 설명
- [x] `/applications/employment` API를 `/applications/employment/{year}` 패턴으로 변경
- [x] QueryEmploymentRateUseCase에 year 파라미터 전달
- [x] QueryCompanyPort, QueryStudentPort 인터페이스에 year 파라미터 추가
- [x] Repository 쿼리에서 YEAR(CURRENT_DATE) 대신 전달받은 year 기준으로 조회
- [x] SecurityConfig 업데이트

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1054