### PR TITLE
🔗 :: (#1070) [모집의뢰서] 기업 검색 시 모든 모집의뢰서 조회되도록 변경

### DIFF
--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/recruitment/persistence/RecruitmentPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/recruitment/persistence/RecruitmentPersistenceAdapter.java
@@ -94,7 +94,7 @@ public class RecruitmentPersistenceAdapter implements RecruitmentPort {
             )
             .join(recruitAreaCodeEntity.code, codeEntity)
             .where(
-                eqYearsAndRecruitStatus(filter.getYears(), filter.getStatus()),
+                eqYearsAndRecruitStatus(filter.getYears(), filter.getStatus(), filter.getCompanyName()),
                 containsName(filter.getCompanyName()),
                 eqWinterIntern(filter.getWinterIntern()),
                 eqMilitarySupport(filter.getMilitarySupport()),
@@ -344,7 +344,7 @@ public class RecruitmentPersistenceAdapter implements RecruitmentPort {
             )
             .join(recruitAreaCodeEntity.code, codeEntity)
             .where(
-                eqYearsAndRecruitStatus(filter.getYears(), filter.getStatus()),
+                eqYearsAndRecruitStatus(filter.getYears(), filter.getStatus(), filter.getCompanyName()),
                 containsName(filter.getCompanyName()),
                 eqWinterIntern(filter.getWinterIntern()),
                 eqMilitarySupport(filter.getMilitarySupport()),


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 필터링 시 기업 이름만 검색하면 모든 연도에 작성된 기업의 모집의뢰서 조회되도록 변경
- [ ] 중복되는 쿼리 제거 및 메서드 적용

**변경된 쿼리 정리**
1. years와 status 둘 다 없을 때:
  - **회사 이름 있음** -> 모든 년도의 RECRUITING, DONE
  - **회사 이름 없음** -> 올해 RECRUITING만 (기본)
2. years만 없음 -> status만 적용
3. status만 없음 -> years + (RECRUITING, DONE)
4. 둘 다 있음 → years + status 

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- #1070 