### PR TITLE
🔗 :: (#1099) 학생 조회 시 비관적 락 적용으로 중복 지원 방지

### DIFF
--- a/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/CreateApplicationUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/application/usecase/CreateApplicationUseCase.java
@@ -12,7 +12,9 @@ import team.retum.jobis.domain.application.spi.CommandApplicationPort;
 import team.retum.jobis.domain.application.spi.QueryApplicationPort;
 import team.retum.jobis.domain.recruitment.model.Recruitment;
 import team.retum.jobis.domain.recruitment.spi.QueryRecruitmentPort;
+import team.retum.jobis.domain.student.exception.StudentNotFoundException;
 import team.retum.jobis.domain.student.model.Student;
+import team.retum.jobis.domain.student.spi.QueryStudentPort;
 
 import java.util.List;
 
@@ -23,10 +25,14 @@ public class CreateApplicationUseCase {
     private final CommandApplicationPort commandApplicationPort;
     private final QueryApplicationPort queryApplicationPort;
     private final QueryRecruitmentPort queryRecruitmentPort;
+    private final QueryStudentPort queryStudentPort;
     private final SecurityPort securityPort;
 
     public void execute(Long recruitmentId, List<AttachmentRequest> attachmentRequests) {
-        Student student = securityPort.getCurrentStudent();
+        Long studentId = securityPort.getCurrentUserId();
+        Student student = queryStudentPort.getByIdWithPessimisticLock(studentId)
+            .orElseThrow(() -> StudentNotFoundException.EXCEPTION);
+
         Recruitment recruitment = queryRecruitmentPort.getByIdOrThrow(recruitmentId);
 
         recruitment.checkIsApplicable(student.getEntranceYear());

--- a/jobis-application/src/main/java/team/retum/jobis/domain/student/spi/QueryStudentPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/student/spi/QueryStudentPort.java
@@ -29,4 +29,6 @@ public interface QueryStudentPort {
     List<Student> getStudentsByGradeAndClassRoomAndNumberAndEntranceYearOrThrow(List<SchoolNumber> schoolNumbers, int entranceYear);
 
     List<TeacherStudentsVO> getStudentsByName(String name);
+
+    Optional<Student> getByIdWithPessimisticLock(Long id);
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/student/persistence/StudentPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/student/persistence/StudentPersistenceAdapter.java
@@ -2,6 +2,7 @@ package team.retum.jobis.domain.student.persistence;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.retum.jobis.domain.application.model.ApplicationStatus;
@@ -182,5 +183,17 @@ public class StudentPersistenceAdapter implements StudentPort {
             .fetch().stream()
             .map(TeacherStudentsVO.class::cast)
             .toList();
+    }
+
+    @Override
+    public Optional<Student> getByIdWithPessimisticLock(Long id) {
+        return Optional.ofNullable(
+                queryFactory
+                    .selectFrom(studentEntity)
+                    .where(studentEntity.id.eq(id))
+                    .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                    .fetchOne()
+            )
+            .map(studentMapper::toDomain);
     }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [ ] 지원서 생성 시 학생 조회에 비관적 락 적용으로 동시 지원 요청에 따른 중복 지원을 방지

## 결과물(있으면)
<!-- 결과 화면 캡처 -->
**락 적용 전**
<img width="656" height="366" alt="image" src="https://github.com/user-attachments/assets/ef071fa0-d552-4e69-a1dd-6a917870f1b8" />

**락 적용 후**
<img width="656" height="610" alt="image" src="https://github.com/user-attachments/assets/ec70829e-3073-47e9-a716-bc0011564bdd" />

## 체크리스트
- [ ] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved # <!-- 이슈번호 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 지원서 생성 시 동시성 제어 강화를 위해 비관적 잠금(Pessimistic Lock) 메커니즘을 적용했습니다. 이를 통해 여러 사용자가 동시에 지원서를 생성할 때 데이터 일관성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->