### PR TITLE
🔗 :: (#1101) 면접 조회 필터 로직 및 응답 구조 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ AGENTS.override.md
 **/AGENTS.override.md
 docs/
 .omx/
+pr-*-comment-audit.md
 *.log
 logs/
 .opencode/**/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -38,12 +38,13 @@ out/
 
 .DS_STORE
 
-
 sonar-project.properties
 
 ### Claude Code ###
 CLAUDE.md
 .claude/*
+AGENTS.md
+.opencode/skills/*
 
 ### AI Agent Files ###
 # Local repository guidance for Codex/agents

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/InterviewFilter.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/InterviewFilter.java
@@ -1,0 +1,18 @@
+package team.retum.jobis.domain.interview.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import team.retum.jobis.domain.recruitment.model.ProgressType;
+
+@Getter
+@Builder
+public class InterviewFilter {
+
+    private final Integer year;
+
+    private final Integer month;
+
+    private final String companyName;
+
+    private final ProgressType interviewType;
+}

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/InterviewFilter.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/InterviewFilter.java
@@ -15,4 +15,6 @@ public class InterviewFilter {
     private final String companyName;
 
     private final ProgressType interviewType;
+
+    private final Long studentId;
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/response/QueryInterviewsResponse.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/dto/response/QueryInterviewsResponse.java
@@ -1,7 +1,7 @@
 package team.retum.jobis.domain.interview.dto.response;
 
 import lombok.Getter;
-import team.retum.jobis.domain.interview.spi.vo.InterviewVO;
+import team.retum.jobis.domain.interview.model.Interview;
 import team.retum.jobis.domain.recruitment.model.ProgressType;
 
 import java.time.LocalDate;
@@ -13,7 +13,7 @@ public class QueryInterviewsResponse {
     private final int totalCount;
     private final List<InterviewResponse> interviews;
 
-    public QueryInterviewsResponse(List<InterviewVO> interviews) {
+    public QueryInterviewsResponse(List<Interview> interviews) {
         this.totalCount = interviews.size();
         this.interviews = interviews.stream()
             .map(InterviewResponse::from)
@@ -29,6 +29,7 @@ public class QueryInterviewsResponse {
         private final String interviewTime;
         private final String companyName;
         private final String location;
+        private final Long studentId;
         private final Long documentNumberId;
 
         private InterviewResponse(
@@ -39,6 +40,7 @@ public class QueryInterviewsResponse {
             String interviewTime,
             String companyName,
             String location,
+            Long studentId,
             Long documentNumberId
         ) {
             this.id = id;
@@ -48,19 +50,21 @@ public class QueryInterviewsResponse {
             this.interviewTime = interviewTime;
             this.companyName = companyName;
             this.location = location;
+            this.studentId = studentId;
             this.documentNumberId = documentNumberId;
         }
 
-        public static InterviewResponse from(InterviewVO vo) {
+        public static InterviewResponse from(Interview interview) {
             return new InterviewResponse(
-                vo.getId(),
-                vo.getInterviewType(),
-                vo.getStartDate(),
-                vo.getEndDate(),
-                vo.getInterviewTime(),
-                vo.getCompanyName(),
-                vo.getLocation(),
-                vo.getDocumentNumberId()
+                interview.getId(),
+                interview.getInterviewType(),
+                interview.getStartDate(),
+                interview.getEndDate(),
+                interview.getInterviewTime(),
+                interview.getCompanyName(),
+                interview.getLocation(),
+                interview.getStudentId(),
+                interview.getDocumentNumberId()
             );
         }
     }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/spi/QueryInterviewPort.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/spi/QueryInterviewPort.java
@@ -1,18 +1,16 @@
 package team.retum.jobis.domain.interview.spi;
 
-import team.retum.jobis.domain.interview.model.Interview;
 import java.time.LocalDate;
-import team.retum.jobis.domain.interview.spi.vo.InterviewVO;
-
 import java.util.List;
+
+import team.retum.jobis.domain.interview.dto.InterviewFilter;
+import team.retum.jobis.domain.interview.model.Interview;
 
 public interface QueryInterviewPort {
 
     List<Interview> getInterviewsByDateRange(LocalDate targetDate);
-  
-    List<InterviewVO> getInterviewsByMonth(Integer year, Integer month);
 
-    List<InterviewVO> getAllInterviews();
+    List<Interview> getInterviewsBy(InterviewFilter filter);
 
     List<Interview> getByIds(List<Long> interviewIds);
 

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/usecase/QueryInterviewsUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/usecase/QueryInterviewsUseCase.java
@@ -2,11 +2,10 @@ package team.retum.jobis.domain.interview.usecase;
 
 import lombok.RequiredArgsConstructor;
 import team.retum.jobis.common.annotation.ReadOnlyUseCase;
+import team.retum.jobis.domain.interview.dto.InterviewFilter;
 import team.retum.jobis.domain.interview.dto.response.QueryInterviewsResponse;
 import team.retum.jobis.domain.interview.spi.QueryInterviewPort;
-import team.retum.jobis.domain.interview.spi.vo.InterviewVO;
-
-import java.util.List;
+import team.retum.jobis.domain.recruitment.model.ProgressType;
 
 @RequiredArgsConstructor
 @ReadOnlyUseCase
@@ -14,15 +13,16 @@ public class QueryInterviewsUseCase {
 
     private final QueryInterviewPort queryInterviewPort;
 
-    public QueryInterviewsResponse execute(Integer year, Integer month) {
-        List<InterviewVO> interviews;
-
-        if (year != null && month != null) {
-            interviews = queryInterviewPort.getInterviewsByMonth(year, month);
-        } else {
-            interviews = queryInterviewPort.getAllInterviews();
-        }
-
-        return new QueryInterviewsResponse(interviews);
+    public QueryInterviewsResponse execute(Integer year, Integer month, String companyName, ProgressType interviewType) {
+        return new QueryInterviewsResponse(
+            queryInterviewPort.getInterviewsBy(
+                InterviewFilter.builder()
+                    .year(year)
+                    .month(month)
+                    .companyName(companyName)
+                    .interviewType(interviewType)
+                    .build()
+            )
+        );
     }
 }

--- a/jobis-application/src/main/java/team/retum/jobis/domain/interview/usecase/QueryInterviewsUseCase.java
+++ b/jobis-application/src/main/java/team/retum/jobis/domain/interview/usecase/QueryInterviewsUseCase.java
@@ -2,6 +2,8 @@ package team.retum.jobis.domain.interview.usecase;
 
 import lombok.RequiredArgsConstructor;
 import team.retum.jobis.common.annotation.ReadOnlyUseCase;
+import team.retum.jobis.common.spi.SecurityPort;
+import team.retum.jobis.domain.auth.model.Authority;
 import team.retum.jobis.domain.interview.dto.InterviewFilter;
 import team.retum.jobis.domain.interview.dto.response.QueryInterviewsResponse;
 import team.retum.jobis.domain.interview.spi.QueryInterviewPort;
@@ -12,6 +14,7 @@ import team.retum.jobis.domain.recruitment.model.ProgressType;
 public class QueryInterviewsUseCase {
 
     private final QueryInterviewPort queryInterviewPort;
+    private final SecurityPort securityPort;
 
     public QueryInterviewsResponse execute(Integer year, Integer month, String companyName, ProgressType interviewType) {
         return new QueryInterviewsResponse(
@@ -21,8 +24,15 @@ public class QueryInterviewsUseCase {
                     .month(month)
                     .companyName(companyName)
                     .interviewType(interviewType)
+                    .studentId(resolveStudentId())
                     .build()
             )
         );
+    }
+
+    private Long resolveStudentId() {
+        return securityPort.getCurrentUserAuthority() == Authority.STUDENT
+            ? securityPort.getCurrentUserId()
+            : null;
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
@@ -4,12 +4,12 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.retum.jobis.domain.interview.dto.InterviewFilter;
 import team.retum.jobis.domain.interview.model.Interview;
 import team.retum.jobis.domain.interview.persistence.mapper.InterviewMapper;
 import team.retum.jobis.domain.interview.persistence.repository.InterviewJpaRepository;
-import team.retum.jobis.domain.interview.persistence.repository.vo.QQueryInterviewVO;
 import team.retum.jobis.domain.interview.spi.InterviewPort;
-import team.retum.jobis.domain.interview.spi.vo.InterviewVO;
+import team.retum.jobis.domain.recruitment.model.ProgressType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -32,52 +32,20 @@ public class InterviewPersistenceAdapter implements InterviewPort {
             )
         );
     }
-  
-    @Override
-    public List<InterviewVO> getInterviewsByMonth(Integer year, Integer month) {
-        return queryFactory
-            .select(
-                new QQueryInterviewVO(
-                    interviewEntity.id,
-                    interviewEntity.interviewType,
-                    interviewEntity.startDate,
-                    interviewEntity.endDate,
-                    interviewEntity.interviewTime,
-                    interviewEntity.companyName,
-                    interviewEntity.location,
-                    interviewEntity.documentNumber.id
-                )
-            )
-            .from(interviewEntity)
-            .where(
-                interviewEntity.startDate.year().eq(year),
-                interviewEntity.startDate.month().eq(month)
-            )
-            .orderBy(interviewEntity.startDate.asc())
-            .fetch().stream()
-            .map(InterviewVO.class::cast)
-            .toList();
-    }
 
     @Override
-    public List<InterviewVO> getAllInterviews() {
+    public List<Interview> getInterviewsBy(InterviewFilter filter) {
         return queryFactory
-            .select(
-                new QQueryInterviewVO(
-                    interviewEntity.id,
-                    interviewEntity.interviewType,
-                    interviewEntity.startDate,
-                    interviewEntity.endDate,
-                    interviewEntity.interviewTime,
-                    interviewEntity.companyName,
-                    interviewEntity.location,
-                    interviewEntity.documentNumber.id
-                )
+            .selectFrom(interviewEntity)
+            .where(
+                eqInterviewYear(filter.getYear()),
+                eqInterviewMonth(filter.getMonth()),
+                containsCompanyName(filter.getCompanyName()),
+                eqInterviewType(filter.getInterviewType())
             )
-            .from(interviewEntity)
             .orderBy(interviewEntity.startDate.asc())
             .fetch().stream()
-            .map(InterviewVO.class::cast)
+            .map(interviewMapper::toDomain)
             .toList();
     }
 
@@ -91,7 +59,7 @@ public class InterviewPersistenceAdapter implements InterviewPort {
             .map(interviewMapper::toDomain)
             .toList();
     }
-  
+
     @Override
     public List<Interview> getByDocumentNumberId(Long documentNumberId) {
         return queryFactory
@@ -102,7 +70,7 @@ public class InterviewPersistenceAdapter implements InterviewPort {
             .map(interviewMapper::toDomain)
             .toList();
     }
-  
+
     @Override
     public List<Interview> getInterviewsByDateRange(LocalDate targetDate) {
         return queryFactory
@@ -125,5 +93,25 @@ public class InterviewPersistenceAdapter implements InterviewPort {
             .and(interviewEntity.endDate.goe(targetDate));
 
         return singleDayInterview.or(multiDayInterview);
+    }
+
+    private BooleanExpression containsCompanyName(String companyName) {
+        if (companyName == null || companyName.isBlank()) {
+            return null;
+        }
+
+        return interviewEntity.companyName.contains(companyName);
+    }
+
+    private BooleanExpression eqInterviewYear(Integer year) {
+        return year == null ? null : interviewEntity.startDate.year().eq(year);
+    }
+
+    private BooleanExpression eqInterviewMonth(Integer month) {
+        return month == null ? null : interviewEntity.startDate.month().eq(month);
+    }
+
+    private BooleanExpression eqInterviewType(ProgressType interviewType) {
+        return interviewType == null ? null : interviewEntity.interviewType.eq(interviewType);
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
@@ -12,6 +12,7 @@ import team.retum.jobis.domain.interview.spi.InterviewPort;
 import team.retum.jobis.domain.recruitment.model.ProgressType;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 import static team.retum.jobis.domain.interview.persistence.entity.QInterviewEntity.interviewEntity;
@@ -38,10 +39,10 @@ public class InterviewPersistenceAdapter implements InterviewPort {
         return queryFactory
             .selectFrom(interviewEntity)
             .where(
-                eqInterviewYear(filter.getYear()),
-                eqInterviewMonth(filter.getMonth()),
+                eqInterviewPeriod(filter.getYear(), filter.getMonth()),
                 containsCompanyName(filter.getCompanyName()),
-                eqInterviewType(filter.getInterviewType())
+                eqInterviewType(filter.getInterviewType()),
+                eqStudentId(filter.getStudentId())
             )
             .orderBy(interviewEntity.startDate.asc())
             .fetch().stream()
@@ -103,15 +104,65 @@ public class InterviewPersistenceAdapter implements InterviewPort {
         return interviewEntity.companyName.contains(companyName);
     }
 
-    private BooleanExpression eqInterviewYear(Integer year) {
-        return year == null ? null : interviewEntity.startDate.year().eq(year);
-    }
+    private BooleanExpression eqInterviewPeriod(Integer year, Integer month) {
+        if (year != null && month != null) {
+            YearMonth yearMonth = YearMonth.of(year, month);
+            return overlapsPeriod(yearMonth.atDay(1), yearMonth.atEndOfMonth());
+        }
 
-    private BooleanExpression eqInterviewMonth(Integer month) {
-        return month == null ? null : interviewEntity.startDate.month().eq(month);
+        if (year != null) {
+            return overlapsPeriod(LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31));
+        }
+
+        if (month != null) {
+            return overlapsMonth(month);
+        }
+
+        return null;
     }
 
     private BooleanExpression eqInterviewType(ProgressType interviewType) {
         return interviewType == null ? null : interviewEntity.interviewType.eq(interviewType);
+    }
+
+    private BooleanExpression eqStudentId(Long studentId) {
+        return studentId == null ? null : interviewEntity.student.id.eq(studentId);
+    }
+
+    private BooleanExpression overlapsPeriod(LocalDate periodStart, LocalDate periodEnd) {
+        BooleanExpression singleDayInterview = interviewEntity.endDate.isNull()
+            .and(interviewEntity.startDate.goe(periodStart))
+            .and(interviewEntity.startDate.loe(periodEnd));
+
+        BooleanExpression multiDayInterview = interviewEntity.endDate.isNotNull()
+            .and(interviewEntity.startDate.loe(periodEnd))
+            .and(interviewEntity.endDate.goe(periodStart));
+
+        return singleDayInterview.or(multiDayInterview);
+    }
+
+    private BooleanExpression overlapsMonth(Integer month) {
+        BooleanExpression singleDayInterview = interviewEntity.endDate.isNull()
+            .and(interviewEntity.startDate.month().eq(month));
+
+        BooleanExpression sameYearMultiDayInterview = interviewEntity.endDate.isNotNull()
+            .and(interviewEntity.startDate.year().eq(interviewEntity.endDate.year()))
+            .and(interviewEntity.startDate.month().loe(month))
+            .and(interviewEntity.endDate.month().goe(month));
+
+        BooleanExpression crossYearAdjacentInterview = interviewEntity.endDate.isNotNull()
+            .and(interviewEntity.endDate.year().subtract(interviewEntity.startDate.year()).eq(1))
+            .and(
+                interviewEntity.startDate.month().loe(month)
+                    .or(interviewEntity.endDate.month().goe(month))
+            );
+
+        BooleanExpression crossYearLongInterview = interviewEntity.endDate.isNotNull()
+            .and(interviewEntity.endDate.year().subtract(interviewEntity.startDate.year()).gt(1));
+
+        return singleDayInterview
+            .or(sameYearMultiDayInterview)
+            .or(crossYearAdjacentInterview)
+            .or(crossYearLongInterview);
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
@@ -105,6 +105,10 @@ public class InterviewPersistenceAdapter implements InterviewPort {
     }
 
     private BooleanExpression eqInterviewPeriod(Integer year, Integer month) {
+        if (!isValidMonth(month)) {
+            return null;
+        }
+
         if (year != null && month != null) {
             YearMonth yearMonth = YearMonth.of(year, month);
             return overlapsPeriod(yearMonth.atDay(1), yearMonth.atEndOfMonth());
@@ -119,6 +123,10 @@ public class InterviewPersistenceAdapter implements InterviewPort {
         }
 
         return null;
+    }
+
+    private boolean isValidMonth(Integer month) {
+        return month == null || (month >= 1 && month <= 12);
     }
 
     private BooleanExpression eqInterviewType(ProgressType interviewType) {

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/persistence/InterviewPersistenceAdapter.java
@@ -106,7 +106,9 @@ public class InterviewPersistenceAdapter implements InterviewPort {
 
     private BooleanExpression eqInterviewPeriod(Integer year, Integer month) {
         if (!isValidMonth(month)) {
-            return null;
+            return year == null
+                ? null
+                : overlapsPeriod(LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31));
         }
 
         if (year != null && month != null) {

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/presentation/InterviewWebAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/presentation/InterviewWebAdapter.java
@@ -14,6 +14,7 @@ import team.retum.jobis.domain.interview.dto.response.QueryInterviewsResponse;
 import team.retum.jobis.domain.interview.presentation.dto.InterviewWebRequest;
 import team.retum.jobis.domain.interview.usecase.CreateInterviewUseCase;
 import team.retum.jobis.domain.interview.usecase.QueryInterviewsUseCase;
+import team.retum.jobis.domain.recruitment.model.ProgressType;
 
 @RequiredArgsConstructor
 @RequestMapping("/interviews")
@@ -30,10 +31,12 @@ public class InterviewWebAdapter {
     }
 
     @GetMapping
-    public QueryInterviewsResponse getInterviews(
-        @RequestParam(required = false) Integer year,
-        @RequestParam(required = false) Integer month
+    public QueryInterviewsResponse queryInterviews(
+        @RequestParam(value = "year", required = false) Integer year,
+        @RequestParam(value = "month", required = false) Integer month,
+        @RequestParam(value = "company_name", required = false) String companyName,
+        @RequestParam(value = "interview_type", required = false) ProgressType interviewType
     ) {
-        return queryInterviewsUseCase.execute(year, month);
+        return queryInterviewsUseCase.execute(year, month, companyName, interviewType);
     }
 }

--- a/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/presentation/InterviewWebAdapter.java
+++ b/jobis-infrastructure/src/main/java/team/retum/jobis/domain/interview/presentation/InterviewWebAdapter.java
@@ -1,8 +1,11 @@
 package team.retum.jobis.domain.interview.presentation;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import team.retum.jobis.domain.interview.usecase.CreateInterviewUseCase;
 import team.retum.jobis.domain.interview.usecase.QueryInterviewsUseCase;
 import team.retum.jobis.domain.recruitment.model.ProgressType;
 
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/interviews")
 @RestController
@@ -33,6 +37,8 @@ public class InterviewWebAdapter {
     @GetMapping
     public QueryInterviewsResponse queryInterviews(
         @RequestParam(value = "year", required = false) Integer year,
+        @Min(1)
+        @Max(12)
         @RequestParam(value = "month", required = false) Integer month,
         @RequestParam(value = "company_name", required = false) String companyName,
         @RequestParam(value = "interview_type", required = false) ProgressType interviewType


### PR DESCRIPTION
## 작업 내용 설명
- [x] 면접 조회 API의 쿼리 파라미터(`year`, `month`, `company_name`, `interview_type`)를 optional 필터로 동작하도록 정리했습니다.
- [x] 인터뷰 조회 흐름을 `InterviewFilter` DTO 기반으로 통일하고, 응답을 `Interview` 도메인 기준으로 반환하도록 변경했습니다.

## 결과물(있으면)
<!-- 결과 화면 캡처 -->

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] DDL이 변경되었을 경우 flyway 마이그레이션 스크립트를 작성하였나요? (DDL 변경 없음)
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #1101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 면접 조회에 회사명(company_name) 및 면접 유형(interview_type) 쿼리 파라미터 추가
  * 조회 응답에 studentId 필드 추가 (학생 계정일 경우 본인 면접 필터링 반영)

* **리팩토링**
  * 연도/월 외 추가 필터 통합으로 조회 방식 단일화 및 응답 정렬/검색 개선
  * 컨트롤러 입력 검증 강화(@Validated 적용, month 범위 검증)

* **잡무**
  * .gitignore 항목 업데이트 (새 패턴 추가/제거)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->